### PR TITLE
Add Visualizer page

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from ui.data_io_page import *
 from ui.dataloader_page import *
 from ui.model_page import *
 from ui.train_page import *
+from ui.visualizer_page import build_visualizer_ui
 
 def exit_app():
     os._exit(0)
@@ -46,7 +47,10 @@ with gr.Blocks(title="Open Retina UI", css=css) as demo:
 
         with gr.Tab("Train"):
             build_train_ui()
-        
+
+        with gr.Tab("Visualizer"):
+            build_visualizer_ui()
+
         with gr.Row():
             b_exit = gr.Button("Quit Application")
             b_exit.click(exit_app)

--- a/ui/visualizer_page.py
+++ b/ui/visualizer_page.py
@@ -1,0 +1,37 @@
+import gradio as gr
+from ui.global_settings import global_state
+from utils.visualizer import evaluate_model_final
+
+log_messages_visualizer = []
+
+def append_log_visualizer(msg: str):
+    log_messages_visualizer.append(msg)
+    return "\n".join(log_messages_visualizer)
+
+def run_visualizer(n_bootstrap, save_plots, prefix):
+    if global_state.get("model") is None:
+        return append_log_visualizer("❌ Model not loaded.")
+    if global_state.get("merged_data") is None:
+        return append_log_visualizer("❌ Dataset not prepared.")
+    results = evaluate_model_final(
+        global_state["model"],
+        global_state["merged_data"],
+        n_bootstrap=int(n_bootstrap),
+        save_plots=save_plots,
+        plot_prefix=prefix
+    )
+    global_state["visualization_results"] = results
+    return append_log_visualizer("✅ Visualization complete.")
+
+def build_visualizer_ui():
+    with gr.Blocks() as visualizer_page:
+        gr.Markdown("# Visualizer")
+        with gr.Row():
+            n_bootstrap = gr.Number(value=100, label="Bootstrap Samples")
+            save_plots = gr.Checkbox(value=True, label="Save Plots")
+            prefix = gr.Textbox(label="Plot Prefix", value="final_")
+            run_btn = gr.Button("Run Evaluation")
+        output_box = gr.Textbox(lines=10, max_lines=10, interactive=False, label="Console")
+        run_btn.click(run_visualizer, [n_bootstrap, save_plots, prefix], output_box)
+
+    return visualizer_page


### PR DESCRIPTION
## Summary
- add a Visualizer tab for running model evaluation
- wire visualizer tab into main app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847e26388f08329b5bae661ccb14fae